### PR TITLE
Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ Learn more about [the organizations endpoint at the docs](http://codeforamerica.
 
 Alias to `cfapi.orgs()`.
 
+### cfapi.issues([options, ], callback);
+
+Request issues from the CfAPI.
+
+The options object is optional and accepts these properties:
+
+- **per_page:** _Integer_
+  - The number of features to return on each page.
+- **labels:** _String_
+  - Only return Issues that have these labels
+
+Example usage:
+
+```
+cfapi.issues({ labels: "help wanted", per_page: 1 }, function (err, res, body) {
+  console.log(body);
+});
+```
+
 ## Contributing
 - Fork this repo
 - Make a branch for your changes

--- a/example.js
+++ b/example.js
@@ -7,3 +7,11 @@ cfapi.orgs({ per_page: 1, type: 'brigade' }, function (err, res, body) {
 cfapi.projects(function (err, res, body) {
   console.log(body);
 });
+
+cfapi.issues( { per_page: 1 }, function (err, res, body) {
+  console.log(body);
+});
+
+cfapi.issues( { per_page: 1, labels: "help wanted, enhancement" }, function (err, res, body) {
+  console.log(body);
+});

--- a/example.js
+++ b/example.js
@@ -1,10 +1,10 @@
 var cfapi = require('./index');
 
-cfapi.orgs({ per_page: 1, type: 'brigade' }, function (err, res, body) {
+cfapi.orgs( { per_page: 3, type: 'brigade' }, function (err, res, body) {
   console.log(body);
 });
 
-cfapi.projects(function (err, res, body) {
+cfapi.projects( {per_page: 2}, function (err, res, body) {
   console.log(body);
 });
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ var qs = require('querystring');
 module.exports = {
   orgs: organizations,
   organizations: organizations,
-  projects: projects
+  projects: projects,
+  issues: issues
 };
 
 function organizations (opts, cb) {
@@ -15,6 +16,10 @@ function projects (opts, cb) {
   return req('projects', opts, cb);
 }
 
+function issues (opts, cb) {
+  return req('issues', opts, cb);
+}
+
 function req (resource, params, cb) {
   var uri = 'http://codeforamerica.org/api/' + resource;
   
@@ -23,8 +28,15 @@ function req (resource, params, cb) {
     params = null;
   }
   
-  if (params) uri += '?' + qs.stringify(params);
-  
+  if (params) {
+    if ("labels" in params) {
+      params.labels = params.labels.replace(", ", ",")
+      uri += '/labels/' + params.labels
+      delete params.labels
+    }
+    uri += '?' + qs.stringify(params);
+  }
+
   var opts = {
     uri: uri,
     method: 'GET',

--- a/index.js
+++ b/index.js
@@ -22,12 +22,12 @@ function issues (opts, cb) {
 
 function req (resource, params, cb) {
   var uri = 'http://codeforamerica.org/api/' + resource;
-  
+
   if (typeof params === 'function') {
     cb = params;
     params = null;
   }
-  
+
   if (params) {
     if ("labels" in params) {
       params.labels = params.labels.replace(", ", ",")

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "xhr": "^2.0.0"
   },
   "devDependencies": {
+    "tap-spec": "^2.2.0",
     "tape": "^3.0.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,10 +1,25 @@
 var test = require('tape');
+var tapSpec = require('tap-spec');
 var cfapi = require('./index');
 
+test.createStream()
+  .pipe(tapSpec())
+  .pipe(process.stdout);
+
 test('get organizations', function (t) {
-  cfapi.orgs(function (err, res, body) {
-    t.ifError(err);
-    t.ok(body);
+  cfapi.orgs({ per_page: 3 }, function (err, res, body) {
+    t.ifError(err, "No errors");
+    t.ok(body, 200);
+    t.equal(body.objects.length, 3)
+    t.end();
+  });
+});
+
+test('get projects', function (t) {
+  cfapi.projects({ per_page: 2 }, function (err, res, body) {
+    t.ifError(err, "No errors");
+    t.ok(body, 200);
+    t.equal(body.objects.length, 2)
     t.end();
   });
 });
@@ -31,14 +46,6 @@ test('get labeled issue', function (t) {
     }
     t.ok(labels.some(hasHelpWantedLabel), "Returns help wanted label")
     t.ok(labels.some(hasBugLabel), "Returns bug label")
-    t.end();
-  });
-});
-
-test('get organizations', function (t) {
-  cfapi.projects(function (err, res, body) {
-    t.ifError(err);
-    t.ok(body);
     t.end();
   });
 });

--- a/test.js
+++ b/test.js
@@ -9,6 +9,32 @@ test('get organizations', function (t) {
   });
 });
 
+test('get issue', function (t) {
+  cfapi.issues({ per_page: 1 }, function (err, res, body) {
+    t.ifError(err, "No errors");
+    t.ok(body, 200);
+    t.equal(body.objects.length, 1)
+    t.end();
+  });
+});
+
+test('get labeled issue', function (t) {
+  cfapi.issues( { per_page: 1, labels: "help wanted, bug" }, function (err, res, body) {
+    t.ifError(err, "No errors");
+    t.ok(body, 200);
+    labels = body.objects[0].labels
+    function hasHelpWantedLabel(element, index, array) {
+      return element.name == "help wanted"
+    }
+    function hasBugLabel(element, index, array) {
+      return element.name == "bug"
+    }
+    t.ok(labels.some(hasHelpWantedLabel), "Returns help wanted label")
+    t.ok(labels.some(hasBugLabel), "Returns bug label")
+    t.end();
+  });
+});
+
 test('get organizations', function (t) {
   cfapi.projects(function (err, res, body) {
     t.ifError(err);


### PR DESCRIPTION
Now you can get open GitHub Issues from across the civic tech movement. Adds support for the /issues endpoint and the /issues/labels/<labels> endpoint. Includes documentation and tests.
